### PR TITLE
Bug fix for issues seen UG on Feb 8th

### DIFF
--- a/core/orca_comms.py
+++ b/core/orca_comms.py
@@ -154,7 +154,7 @@ def tellie_read(tellie_serial):
             print pin_out
             return '%s|%s' % (comms_flags.tellie_pinout, json.dumps(pin_out))
         else:
-           return comms_flags.tellie_notready
+            return comms_flags.tellie_notready
     except tellie_exception.TellieException, e:
         pin_out = ''
         print e, type(e)

--- a/testing/server/pulse_sequence_slave.py
+++ b/testing/server/pulse_sequence_slave.py
@@ -2,6 +2,7 @@
 from SimpleXMLRPCServer import SimpleXMLRPCServer
 import xmlrpclib
 import sys
+import time
 from common import parameters as p
 
 server = xmlrpclib.ServerProxy("http://localhost:5030")
@@ -29,6 +30,7 @@ if __name__=="__main__":
         safe_exit(server,e)
 
     mean = None
+    start = time.time()
     try:
         print "Waiting for sequence to finish..."
         while (mean == None):
@@ -36,6 +38,11 @@ if __name__=="__main__":
                 mean, rms, chan = server.read_pin_sequence()
             except TypeError:
                 mean = None
+            now = time.time()
+            print "Elapsed time: %.3f seconds..." % (now-start)
+            if (now-start > 8.):
+                print "Timed out (>8 sec). Reading PIN values..."
+                mean, rms, chan = server.read_pin_sequence_timeout()
     except Exception,e:
         safe_exit(server,e)
     except KeyboardInterrupt:


### PR DESCRIPTION
Add new functions to call in case of PIN read timeout.
This can occur in ORCA when a previous subrun did not receive the correct number of triggers.
This fixes a symptom only, it is not a solution for missing EXTA triggers!